### PR TITLE
added dependency review action to the standard go test workflow

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -6,6 +6,9 @@ on:
       CC_TEST_REPORTER_ID:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   standard-go-coverage:
     name: Test Coverage
@@ -16,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.17.x"
+          go-version-file: "go.mod"
 
       - name: Code Climate
         uses: paambaati/codeclimate-action@v3.0.0

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -3,16 +3,27 @@ name: Standard Go Test
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
+  dependency-review:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v1
+
   standard-go-test:
     name: go${{ matrix.go-version }}/${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         go-version:
-          - "1.16.x"
-          - "1.17.x"
-          - "1.18.x"
+          - "1.16"
+          - "1.17"
+          - "1.18"
         os:
           - "ubuntu-latest"
           - "macos-latest"

--- a/README.md
+++ b/README.md
@@ -10,27 +10,31 @@ The default files for all gobuffalo projects.
 
 ### Reusable Workflows
 
-The reusable workflows are shared workflows can be called from the other
+The reusable workflows are shared workflows that can be called from the other
 workflow that is configured for each project.
 
 #### Standard Go Test
 
-The standard go test, `go-test.yml`, will run configured `go test` command
-for caller package on pre-configured environments.
-Currently, the test will run on the latest version of Ubuntu, MacOS, and
+The Standard Go Test, `go-test.yml`, will run configured `go test` command
+for the caller package on pre-configured environments.
+Currently, the test will run on the latest version of Ubuntu, macOS, and
 Windows OSes with supported go versions.
-Current supported go versions are 1.16 and 1.17. 1.18 support will be added
-soon. (1.16 support will be deprecated once 1.18 support is added.)
+The current supported go versions are 1.16 and 1.17. 1.18 support will be
+added soon. (1.16 support will be deprecated once 1.18 support is added.)
+
+Additionally, it runs [Dependency Review Github Action](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement)
+to check if any vulnerable versions of dependencies could be introduced by
+PRs.
 
 #### Standard Go Coverage
 
-The standard go coverage, `go-coverage.yml`, will run coverage test on the
+The Standard Go Coverage, `go-coverage.yml`, will run a coverage test on the
 latest version of Ubuntu with the latest supported version of go (currently
 1.17), and will report the result to Code Climate, Coveralls, and Codecov.
 
 ### Starter Workflows
 
-The starter workflows are a kind of workflow templates which could be used
+The starter workflows are a kind of workflow template that could be used
 for a new project when configuring a test workflow.
 
 #### Standard Go Test for Gobuffalo
@@ -46,7 +50,7 @@ platforms with supported go versions.
 The extended testing workflow for Go packages. (standard test + test coverage)
 
 This starter workflow can be used when configuring a new test that supports
-coverage reporting. It calls reusable workflow "Standard Go Test"
+coverage reporting. It calls the reusable workflow "Standard Go Test"
 (`go-test.yml`) to run tests on supported platforms with supported go versions,
 then calls another reusable workflow "Standard Go Coverage" (`go-coverage.yml`)
 to run a coverage test on the latest version of Ubuntu with the latest
@@ -54,6 +58,6 @@ supported version of go.
 
 To use this test, the caller project should have a `secret` named
 `CC_TEST_REPORTER_ID` (Code Climate's reporter ID) then the secret will be
-automatically passed to the called workflow and will be used when reusable
-workflow runs coverage report.
+automatically passed to the called workflow and will be used when the reusable
+workflow runs the coverage report.
 


### PR DESCRIPTION
Adding Dependency Review Action to the Standard Go Test workflow. (and some README update)

The change was requested by @naveensrinivasan as https://github.com/gobuffalo/buffalo/pull/2267 for the `buffalo` repository but it could be better if we add it as a standard workflow for all repositories.